### PR TITLE
chore: dependencies strategy for package release

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Install packages
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Commit lint
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,3 +25,17 @@ jobs:
         with:
           commit-lint-from: ${{ github.event.pull_request.base.sha }}
           commit-lint-to: ${{ github.event.pull_request.head.sha }}
+
+  check-provenance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check dependency provenance
+        uses: danielroe/provenance-action@41bcc969e579d9e29af08ba44fcbfdf95cee6e6c # v0.1.1
+        with:
+          fail-on-downgrade: 'true'
+          fail-on-provenance-change: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install packages
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm run build
@@ -119,7 +119,7 @@ jobs:
           unzip -q "artifacts/package.zip" -d dist
 
       - name: Install dependencies to get semantic release components and plugins
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Semantic release
         run: pnpm exec semantic-release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 registry=https://registry.npmjs.org/
 ignore-scripts=true
+block-exotic-subdeps=true
+minimum-release-age=10080

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 registry=https://registry.npmjs.org/
+provenance=true
 ignore-scripts=true
 block-exotic-subdeps=true
 minimum-release-age=10080

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,22 @@
 
 This SDK has no runtime dependencies; this keeps things lean for consumers and avoids security issues from packages we don't control. The published package is TypeScript-compiled output only. All dependencies are either `devDependencies` (build/test tooling) or `peerDependencies` (installed by the consumer).
 
+### Supply chain protections (`.npmrc`)
+
+- `ignore-scripts=true`: blocks postinstall scripts. The build is pure `tsc`, so none are needed.
+- `block-exotic-subdeps=true`: prevents transitive deps from using git repos or tarball URLs as sources.
+- `minimum-release-age=10080`: delays installation of newly published packages by 7 days, avoiding the window between malicious publication and detection.
+
 ### Version specifiers
 
 - DevDependencies use caret ranges (`^`). The lockfile pins exact versions with SHA-512 hashes; the caret is the update policy, not what actually gets installed.
-- `@algorandfoundation/*` alpha packages are pinned to exact versions. Pre-releases can break without warning, so bumps should be deliberate until stable releases are ready.
+- `@algorandfoundation/*` alpha packages are pinned to exact versions. Pre-releases can break without warning, so bumps should be deliberate.
 
 ### Lockfile
 
 - `pnpm-lock.yaml` is committed. It's what makes installs reproducible.
-- CI runs `pnpm install --frozen-lockfile --ignore-scripts`, failing if the lockfile is out of sync, and blocking postinstall scripts as a supply chain precaution.
+- CI runs `pnpm install --frozen-lockfile --ignore-scripts`.
+- Postinstall scripts are blocked as a supply chain precaution.
 
 ### Transitive dependency overrides (`pnpm.overrides`)
 
@@ -22,5 +29,5 @@ This SDK has no runtime dependencies; this keeps things lean for consumers and a
 
 ### Updates
 
-- Dependabot proposes grouped minor+patch updates monthly. `@algorandfoundation/*` packages are excluded from automation.
-- Security updates from Dependabot run on their own schedule, outside the monthly batch.
+- Dependabot proposes grouped minor+patch updates monthly.
+- Security updates run on their own schedule in repo settings, outside the monthly batch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Dependency Management
+
+This SDK has no runtime dependencies, this keeps things lean for consumers and avoids security issues from packages we don't control. The published package is TypeScript-compiled output only. All dependencies are either `devDependencies` (build/test tooling) or `peerDependencies` (installed by the consumer).
+
+### Version specifiers
+
+- DevDependencies use caret ranges (`^`). The lockfile pins exact versions with SHA-512 hashes — the caret is the update policy, not what actually gets installed.
+- `@algorandfoundation/*` alpha packages are pinned to exact versions. Pre-releases can break without warning, so bumps should be deliberate.
+
+### Lockfile
+
+- `pnpm-lock.yaml` is committed. It's what makes installs reproducible.
+- CI runs `pnpm install --frozen-lockfile --ignore-scripts` — fails if the lockfile is out of sync, and blocks postinstall scripts as a supply chain precaution.
+
+### Transitive dependency overrides (`pnpm.overrides`)
+
+- Only add an override when `pnpm audit --audit-level=high` reports a vulnerability with no upstream fix yet.
+- Use conditional range syntax (e.g. `rollup@>=4.0.0 <4.59.0: >=4.59.0`) to limit the override to the affected range.
+- Review quarterly: re-run `pnpm audit` without overrides to drop any that are no longer needed.
+
+### Updates
+
+- Dependabot proposes grouped minor+patch updates monthly. `@algorandfoundation/*` packages are excluded from automation.
+- Security updates from Dependabot run on their own schedule, outside the monthly batch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 
 ## Dependency Management
 
-This SDK has no runtime dependencies, this keeps things lean for consumers and avoids security issues from packages we don't control. The published package is TypeScript-compiled output only. All dependencies are either `devDependencies` (build/test tooling) or `peerDependencies` (installed by the consumer).
+This SDK has no runtime dependencies; this keeps things lean for consumers and avoids security issues from packages we don't control. The published package is TypeScript-compiled output only. All dependencies are either `devDependencies` (build/test tooling) or `peerDependencies` (installed by the consumer).
 
 ### Version specifiers
 
-- DevDependencies use caret ranges (`^`). The lockfile pins exact versions with SHA-512 hashes — the caret is the update policy, not what actually gets installed.
-- `@algorandfoundation/*` alpha packages are pinned to exact versions. Pre-releases can break without warning, so bumps should be deliberate.
+- DevDependencies use caret ranges (`^`). The lockfile pins exact versions with SHA-512 hashes; the caret is the update policy, not what actually gets installed.
+- `@algorandfoundation/*` alpha packages are pinned to exact versions. Pre-releases can break without warning, so bumps should be deliberate until stable releases are ready.
 
 ### Lockfile
 
 - `pnpm-lock.yaml` is committed. It's what makes installs reproducible.
-- CI runs `pnpm install --frozen-lockfile --ignore-scripts` — fails if the lockfile is out of sync, and blocks postinstall scripts as a supply chain precaution.
+- CI runs `pnpm install --frozen-lockfile --ignore-scripts`, failing if the lockfile is out of sync, and blocking postinstall scripts as a supply chain precaution.
 
 ### Transitive dependency overrides (`pnpm.overrides`)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Node: 22.17.0 (see `.nvmrc`)
 ```sh
 git submodule update --init --recursive
 pnpm install
+pnpm exec husky
 ```
+
+> `ignore-scripts=true` is set in `.npmrc` to block postinstall scripts from running on install. This means husky won't set up git hooks automatically and should be manually executed after cloning.
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ pnpm run lint
 ```
 
 This project uses **Husky** and **lint-staged** to automatically lint and format staged files before they are committed.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for dependency policy and lockfile rules.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "prepare": "husky"
+    "format:check": "prettier --check ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,12 @@
           }
         }
       ],
-      "@semantic-release/npm",
+      [
+        "@semantic-release/npm",
+        {
+          "provenance": true
+        }
+      ],
       "@semantic-release/github"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
   "scripts": {
     "clean": "rm -rf dist/",
     "build:cjs": "tsc --project tsconfig.cjs.json",

--- a/package.json
+++ b/package.json
@@ -68,15 +68,7 @@
     "@algorandfoundation/algokit-utils": "10.0.0-alpha.40"
   },
   "pnpm": {
-    "overrides": {
-      "minimatch": ">=10.2.3",
-      "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
-      "picomatch@<2.3.2": "2.3.2",
-      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
-      "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
-      "brace-expansion@<5.0.5": ">=5.0.5",
-      "handlebars@>=4.0.0 <4.7.9": ">=4.7.9"
-    }
+    "overrides": {}
   },
   "lint-staged": {
     "*.{ts,js,mjs,cjs}": [

--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
       "prettier --write"
     ]
   },
+  "engines": {
+    "node": ">=22.17.0"
+  },
   "packageManager": "pnpm@9.15.4",
   "release": {
     "branches": [

--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
   "peerDependencies": {
     "@algorandfoundation/algokit-utils": "10.0.0-alpha.40"
   },
-  "pnpm": {
-    "overrides": {}
-  },
   "lint-staged": {
     "*.{ts,js,mjs,cjs}": [
       "prettier --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,15 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  minimatch: '>=10.2.3'
-  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
-  picomatch@<2.3.2: 2.3.2
-  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
-  yaml@>=2.0.0 <2.8.3: '>=2.8.3'
-  brace-expansion@<5.0.5: '>=5.0.5'
-  handlebars@>=4.0.0 <4.7.9: '>=4.7.9'
-
 importers:
 
   .:
@@ -1249,7 +1240,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2370,7 +2361,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true


### PR DESCRIPTION
## Summary

Harden the supply chain security strategy ahead of its public release as an npm package.                                                      
   
## Changes

1. Create `.npmrc` with `--ignore-scripts` and add the flag explicitly in all CI install steps (not necessary with new `.npmrc` but doesn't hurt having it).
2. Add `minimumReleaseAge` to 7 days and `blockExoticSubdeps` as [recommended by pnpm](https://pnpm.io/supply-chain-security).
3. Enable npm provenance via `@semantic-release/npm`, so published packages are cryptographically linked to their GitHub Actions build.                                                                                                     
4. Pin the registry to `registry.npmjs.org` in `.npmrc`  to ensure all installs use the official npm registry.
5. Add engines field requiring Node `>=22.17.0`.
6. Document dependency policy in `CONTRIBUTING.md`.
7. Remove stale pnpm overrides. 

### How each policy area is addressed 

**Version specifiers:** Keep caret ranges (^) for devDependencies - the lockfile already pins exact versions, so carets only control what Dependabot is allowed to propose. The two `@algorandfoundation/*` alpha packages are the exception, they are exact-pinned as pre-release semver has no stability guarantees. Once `algokit-utils` reaches stable, the peer dependency can be widen to `^10.0.0`. 

**Lockfile policy:** `pnpm-lock.yaml` is committed and is the source of truth. CI runs `--frozen-lockfile`, so any drift between `package.json` and the lockfile fails the build. No changes needed, already in place.

**Update cadence:** Dependabot proposes grouped minor+patch updates monthly. `. Security updates are handled separately in repo settings.

**Overrides/resolutions:** Policy documented in CONTRIBUTING - add only when `pnpm audit --audit-level=high` has no upstream fix, review quarterly to prune stale entries.
                                                                                                                                                 
**Install mode:** `--frozen-lockfile` was already enforced. Now also running `--ignore-scripts` (see 1) to block postinstall script execution from all dependencies. Our build is pure tsc, so no install scripts are needed.
                                                                                                                                                 
**Registry & integrity:** `.npmrc` now pins the registry to `npmjs.org` (see 4) and enforces `block-exotic-subdeps=true` (see 2), preventing transitive dependencies from using git repos or tarball URLs. Lockfile already stores SHA-512 hashes for every package. npm provenance (see 3) adds cryptographic attestation linking published packages to their CI build. Additionally, `minimum-release-age=10080` delays installation of newly published packages by 7 days, avoiding the window between malicious publication and detection. Note: this applies locally on pnpm update or when adding new deps, CI is unaffected due to `--frozen-lockfile`.

### Dependency architecture
                                                                                                                                                 
This SDK has zero runtime dependencies: the published `dist/` is self-contained TypeScript-compiled output with no npm imports at runtime. So installing the SDK pulls in zero transitive dependencies.                        
                  
All 23 packages are devDependencies (TypeScript, ESLint, Vitest, etc.), meaning they only exist on developer machines and CI runners, never reaching consumers. This is why blocking install scripts is the most impactful change in this PR: these are the only packages ever installed in this repo, and none of them need postinstall scripts to produce the final output.                                                 
                  
There's only one peerDependency and it's `algokit-utils`.
                                                        