### PR TITLE
fix(migrate): handle non-zero metadata hash on legacy ASAs

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,12 @@
     "node": ">=22.17.0"
   },
   "packageManager": "pnpm@9.15.4",
+  "pnpm": {
+    "overrides": {
+      "vite@>=7.0.0 <7.3.2": ">=7.3.2",
+      "lodash-es@>=4.0.0 <=4.17.23": ">=4.18.0"
+    }
+  },
   "release": {
     "branches": [
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite@>=7.0.0 <7.3.2: '>=7.3.2'
+  lodash-es@>=4.0.0 <=4.17.23: '>=4.18.0'
+
 importers:
 
   .:
@@ -34,7 +38,7 @@ importers:
         version: 8.56.1(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -73,7 +77,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3)
+        version: 4.0.18(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
 
 packages:
 
@@ -212,6 +216,15 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -429,6 +442,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/ciphers@2.1.1':
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
@@ -492,6 +511,9 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@oxc-project/types@0.123.0':
+    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
+
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -508,130 +530,97 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -682,6 +671,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -779,7 +771,7 @@ packages:
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: '>=7.3.2'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1065,6 +1057,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1573,6 +1569,76 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1597,8 +1663,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -1953,8 +2019,8 @@ packages:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2034,9 +2100,9 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.0.0-rc.13:
+    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rxjs@7.8.2:
@@ -2346,15 +2412,16 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@8.0.7:
+    resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -2365,11 +2432,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -2691,6 +2760,22 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.3.0
 
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -2821,6 +2906,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@noble/ciphers@2.1.1': {}
 
   '@noble/curves@2.0.1':
@@ -2891,6 +2983,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@oxc-project/types@0.123.0': {}
+
   '@pkgr/core@0.2.9': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
@@ -2905,80 +2999,56 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.59.0':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.59.0':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    optional: true
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -2990,7 +3060,7 @@ snapshots:
       conventional-commits-parser: 6.3.0
       debug: 4.4.3
       import-from-esm: 2.0.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       micromatch: 4.0.8
       semantic-release: 25.0.3(typescript@5.9.3)
     transitivePeerDependencies:
@@ -3011,7 +3081,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       issue-parser: 7.0.1
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
@@ -3029,7 +3099,7 @@ snapshots:
       env-ci: 11.2.0
       execa: 9.6.1
       fs-extra: 11.3.4
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       nerf-dart: 1.0.0
       normalize-url: 9.0.0
       npm: 11.12.0
@@ -3050,7 +3120,7 @@ snapshots:
       get-stream: 7.0.1
       import-from-esm: 2.0.0
       into-stream: 7.0.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       read-package-up: 11.0.0
       semantic-release: 25.0.3(typescript@5.9.3)
     transitivePeerDependencies:
@@ -3067,6 +3137,11 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3178,7 +3253,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -3190,7 +3265,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3)
+      vitest: 4.0.18(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -3201,13 +3276,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.0.18(vite@8.0.7(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.7(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -3484,6 +3559,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  detect-libc@2.1.2: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -3547,6 +3624,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+    optional: true
 
   escalade@3.2.0: {}
 
@@ -3977,6 +4055,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lines-and-columns@1.2.4: {}
 
   lint-staged@16.3.1:
@@ -4013,7 +4140,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -4265,7 +4392,7 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
-  postcss@8.5.6:
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4353,36 +4480,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.59.0:
+  rolldown@1.0.0-rc.13:
     dependencies:
-      '@types/estree': 1.0.8
+      '@oxc-project/types': 0.123.0
+      '@rolldown/pluginutils': 1.0.0-rc.13
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.59.0
-      '@rollup/rollup-android-arm64': 4.59.0
-      '@rollup/rollup-darwin-arm64': 4.59.0
-      '@rollup/rollup-darwin-x64': 4.59.0
-      '@rollup/rollup-freebsd-arm64': 4.59.0
-      '@rollup/rollup-freebsd-x64': 4.59.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-      '@rollup/rollup-linux-arm64-gnu': 4.59.0
-      '@rollup/rollup-linux-arm64-musl': 4.59.0
-      '@rollup/rollup-linux-loong64-gnu': 4.59.0
-      '@rollup/rollup-linux-loong64-musl': 4.59.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-      '@rollup/rollup-linux-ppc64-musl': 4.59.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-      '@rollup/rollup-linux-riscv64-musl': 4.59.0
-      '@rollup/rollup-linux-s390x-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-musl': 4.59.0
-      '@rollup/rollup-openbsd-x64': 4.59.0
-      '@rollup/rollup-openharmony-arm64': 4.59.0
-      '@rollup/rollup-win32-arm64-msvc': 4.59.0
-      '@rollup/rollup-win32-ia32-msvc': 4.59.0
-      '@rollup/rollup-win32-x64-gnu': 4.59.0
-      '@rollup/rollup-win32-x64-msvc': 4.59.0
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
   rxjs@7.8.2:
     dependencies:
@@ -4409,7 +4526,7 @@ snapshots:
       hook-std: 4.0.0
       hosted-git-info: 9.0.2
       import-from-esm: 2.0.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       marked: 15.0.12
       marked-terminal: 7.3.0(marked@15.0.12)
       micromatch: 4.0.8
@@ -4670,24 +4787,24 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.7(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.59.0
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.3.3
+      esbuild: 0.27.3
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3):
+  vitest@4.0.18(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@8.0.7(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -4704,14 +4821,15 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.7(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - msw
       - sass
       - sass-embedded

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -10,6 +10,7 @@ import { Transaction } from '@algorandfoundation/algokit-utils/transact'
 import { ARC2_ARC_NUMBER, ARC2_DATA_FORMAT_JSON, MAX_GROUP_SIZE, MAX_METADATA_SIZE } from './constants'
 import { Arc90Compliance, Arc90Uri } from './codec'
 import { MissingAppClientError } from './errors'
+import { MASK_IRR_ARC3, MASK_IRR_IMMUTABLE } from './bitmasks'
 import { AssetMetadata, MetadataFlags } from './models'
 import { concatBytes } from './internal/bytes'
 import type { AsaMetadataRegistry } from './registry'
@@ -98,8 +99,10 @@ export function deriveMigrationUri(args: {
  * Flow:
  * 1) Error if metadata already exists in the Registry for the given ASA.
  * 2) Error if metadata is flagged as ARC-89 native.
- * 3) Validate metadata size <= MAX_METADATA_SIZE (raw bytes after JSON encoding).
- * 4) Create metadata on the registry and emit the ARC-2 migration message.
+ * 3) If the ASA has a non-zero asset metadata hash (am): auto-set immutable when no flags provided,
+ *    or error early if flags are provided without immutable: true.
+ * 4) Validate metadata size <= MAX_METADATA_SIZE (raw bytes after JSON encoding).
+ * 5) Create metadata on the registry and emit the ARC-2 migration message.
  */
 export async function migrateLegacyMetadataToRegistry(args: {
   registry: AsaMetadataRegistry
@@ -109,24 +112,39 @@ export async function migrateLegacyMetadataToRegistry(args: {
   arc3Compliant: boolean
   flags?: MetadataFlags | null
 }): Promise<void> {
-  // Pre-flight: ensure not already migrated
+  // Pre-flight: ensure ASA exists and is not already migrated
   const existence = await args.registry.read.arc89CheckMetadataExists({ assetId: args.assetId })
+  if (!existence.asaExists) {
+    throw new Error(`ASA ${args.assetId} does not exist`)
+  }
   if (existence.metadataExists) {
     throw new Error(`ASA ${args.assetId} already has metadata in this registry; migration is not allowed`)
   }
 
-  // Validate flags
-  if (args.flags?.irreversible.arc89Native) {
-    throw new Error('Cannot flag migrated metadata as ARC-89 native')
+  if (args.flags?.irreversible.arc89Native) throw new Error('Cannot flag migrated metadata as ARC-89 native')
+
+  // Pre-flight: fetch ASA info to check metadata hash and decide on flags
+  const assetInfo = await args.registry.write.client.algorand.asset.getById(BigInt(args.assetId))
+  const hasMetadataHash = assetInfo.metadataHash != null && assetInfo.metadataHash.some((b) => b !== 0)
+  if (hasMetadataHash && args.flags != null && !args.flags.irreversible.immutable) {
+    throw new Error(
+      `ASA ${args.assetId} has a metadata hash (am) set on-chain, hence the registry ` +
+        `requires the IMMUTABLE flag for this migration. Either omit flags to set it ` +
+        `automatically, or pass flags with immutable: true.`,
+    )
   }
 
-  // Build AssetMetadata and enforce size bounds
+  // Build AssetMetadata, resolve flags if not provided and enforce size bounds
   let assetMd: AssetMetadata
   try {
     assetMd = AssetMetadata.fromJson({
       assetId: args.assetId,
       jsonObj: args.metadata,
-      flags: args.flags ?? undefined,
+      flags:
+        args.flags ??
+        (hasMetadataHash
+          ? MetadataFlags.fromBytes(0, MASK_IRR_IMMUTABLE | (args.arc3Compliant ? MASK_IRR_ARC3 : 0))
+          : undefined),
       arc3Compliant: args.arc3Compliant,
     })
   } catch (e) {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -10,7 +10,7 @@ import { Transaction } from '@algorandfoundation/algokit-utils/transact'
 import { ARC2_ARC_NUMBER, ARC2_DATA_FORMAT_JSON, MAX_GROUP_SIZE, MAX_METADATA_SIZE } from './constants'
 import { Arc90Compliance, Arc90Uri } from './codec'
 import { MissingAppClientError } from './errors'
-import { MASK_IRR_ARC3, MASK_IRR_IMMUTABLE } from './bitmasks'
+import { MASK_IRR_IMMUTABLE } from './bitmasks'
 import { AssetMetadata, MetadataFlags } from './models'
 import { concatBytes } from './internal/bytes'
 import type { AsaMetadataRegistry } from './registry'
@@ -97,7 +97,7 @@ export function deriveMigrationUri(args: {
  * in the ASA Metadata Registry, then emitting an ARC-2 migration message.
  *
  * Flow:
- * 1) Error if metadata already exists in the Registry for the given ASA.
+ * 1) Error if metadata already exists in the Registry for the given ASA; error if the ASA does not exist.
  * 2) Error if metadata is flagged as ARC-89 native.
  * 3) If the ASA has a non-zero asset metadata hash (am): auto-set immutable when no flags provided,
  *    or error early if flags are provided without immutable: true.
@@ -140,13 +140,21 @@ export async function migrateLegacyMetadataToRegistry(args: {
     assetMd = AssetMetadata.fromJson({
       assetId: args.assetId,
       jsonObj: args.metadata,
-      flags:
-        args.flags ??
-        (hasMetadataHash
-          ? MetadataFlags.fromBytes(0, MASK_IRR_IMMUTABLE | (args.arc3Compliant ? MASK_IRR_ARC3 : 0))
-          : undefined),
+      flags: args.flags ?? undefined,
       arc3Compliant: args.arc3Compliant,
     })
+    // Set immutable flag after derivation to preserve auto-detected reversible flags (e.g. ARC-20/ARC-62)
+    if (hasMetadataHash && args.flags == null) {
+      assetMd = new AssetMetadata({
+        assetId: assetMd.assetId,
+        body: assetMd.body,
+        flags: MetadataFlags.fromBytes(
+          assetMd.flags.reversibleByte,
+          assetMd.flags.irreversibleByte | MASK_IRR_IMMUTABLE,
+        ),
+        deprecatedBy: assetMd.deprecatedBy,
+      })
+    }
   } catch (e) {
     if (e instanceof RangeError) {
       throw new Error(

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -119,12 +119,18 @@ export const createArc3Asa = async (args: {
   return result.assetId
 }
 
-/** Create a legacy ARC-3 ASA (without ARC-89 registry URL). */
+/** Create a legacy ARC-3 ASA (without ARC-89 registry URL).
+ * If `withMetadataHash` is true, includes a non-zero metadata hash to trigger ARC-3 logic in the registry.
+ */
 export const createLegacyArc3Asa = async (args: {
   assetManager: AddressWithSigners
   appClient: AsaMetadataRegistryClient
+  withMetadataHash?: boolean
 }): Promise<bigint> => {
   const arc3Suffix = new TextDecoder().decode(ARC3_NAME_SUFFIX)
+  const metadataHash = args.withMetadataHash
+    ? new Uint8Array(32).fill(0xab) // non-zero 32-byte placeholder
+    : undefined
   const result = await args.appClient.algorand.send.assetCreate({
     sender: args.assetManager.addr,
     total: 1000n,
@@ -136,6 +142,7 @@ export const createLegacyArc3Asa = async (args: {
     reserve: args.assetManager.addr,
     freeze: args.assetManager.addr,
     clawback: args.assetManager.addr,
+    metadataHash,
   })
   return result.assetId
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -104,51 +104,46 @@ export const createArc89Asa = async (args: {
   return result.assetId
 }
 
-/** Create a valid ARC-3 ASA (`assetName` ends with `@arc3`) */
+/**
+ * Create a legacy ARC-3 ASA (`assetName` ends with `@arc3`).
+ * When `preRegistry` is true, simulates a pre-registry ARC-3 with an IPFS URL, all manager addresses set,
+ * and an optional `withMetadataHash` flag. If `withMetadataHash` is true, includes a non-zero metadata
+ * hash to trigger ARC-3 logic in the registry.
+ */
 export const createArc3Asa = async (args: {
   assetManager: AddressWithSigners
   appClient: AsaMetadataRegistryClient
-}): Promise<bigint> => {
-  const arc3Suffix = new TextDecoder().decode(ARC3_NAME_SUFFIX)
-  const result = await args.appClient.algorand.send.assetCreate({
-    sender: args.assetManager.addr,
-    total: 42n,
-    assetName: `ARC3 Test ASA${arc3Suffix}`,
-    manager: args.assetManager.addr,
-  })
-  return result.assetId
-}
-
-/** Create a legacy ARC-3 ASA (without ARC-89 registry URL).
- * If `withMetadataHash` is true, includes a non-zero metadata hash to trigger ARC-3 logic in the registry.
- */
-export const createLegacyArc3Asa = async (args: {
-  assetManager: AddressWithSigners
-  appClient: AsaMetadataRegistryClient
+  preRegistry?: boolean
   withMetadataHash?: boolean
 }): Promise<bigint> => {
   const arc3Suffix = new TextDecoder().decode(ARC3_NAME_SUFFIX)
-  const metadataHash = args.withMetadataHash
-    ? new Uint8Array(32).fill(0xab) // non-zero 32-byte placeholder
-    : undefined
-  const result = await args.appClient.algorand.send.assetCreate({
-    sender: args.assetManager.addr,
-    total: 1000n,
-    assetName: `Legacy NFT${arc3Suffix}`,
-    unitName: 'LNFT',
-    url: 'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
-    decimals: 0,
-    manager: args.assetManager.addr,
-    reserve: args.assetManager.addr,
-    freeze: args.assetManager.addr,
-    clawback: args.assetManager.addr,
-    metadataHash,
-  })
+  const result = await args.appClient.algorand.send.assetCreate(
+    args.preRegistry
+      ? {
+          sender: args.assetManager.addr,
+          total: 1000n,
+          assetName: `Legacy NFT${arc3Suffix}`,
+          unitName: 'LNFT',
+          url: 'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+          decimals: 0,
+          manager: args.assetManager.addr,
+          reserve: args.assetManager.addr,
+          freeze: args.assetManager.addr,
+          clawback: args.assetManager.addr,
+          metadataHash: args.withMetadataHash ? new Uint8Array(32).fill(0xab) : undefined,
+        }
+      : {
+          sender: args.assetManager.addr,
+          total: 42n,
+          assetName: `ARC3 Test ASA${arc3Suffix}`,
+          manager: args.assetManager.addr,
+        },
+  )
   return result.assetId
 }
 
 /** Create a legacy ARC-69 ASA with metadata in the note field. */
-export const createLegacyArc69Asa = async (args: {
+export const createArc69Asa = async (args: {
   assetManager: AddressWithSigners
   appClient: AsaMetadataRegistryClient
   metadata?: Record<string, unknown>

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -333,6 +333,28 @@ describe('migrate legacy metadata', () => {
     ).rejects.toThrow('IMMUTABLE flag')
   })
 
+  test('migrate arc3 asa with metadataHash and arc20 properties preserves arc20 flag', async () => {
+    const assetId = await createArc3Asa({ assetManager, appClient: client, preRegistry: true, withMetadataHash: true })
+
+    const arc3WithArc20: Record<string, unknown> = {
+      name: 'ARC-20 Token',
+      properties: { 'arc-20': { 'application-id': 999 } },
+    }
+
+    await migrateLegacyMetadataToRegistry({
+      registry,
+      assetManager,
+      assetId,
+      metadata: arc3WithArc20,
+      arc3Compliant: true,
+    })
+
+    const header = await registry.read.arc89GetMetadataHeader({ assetId })
+    expect(header.flags.irreversible.immutable).toBe(true)
+    expect(header.flags.irreversible.arc3).toBe(true)
+    expect(header.flags.reversible.arc20).toBe(true)
+  })
+
   test('migrate arc69 preserves exact metadata', async () => {
     const originalMetadata: Record<string, unknown> = {
       standard: 'arc69',

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -295,6 +295,43 @@ describe('migrate legacy metadata', () => {
     expect(header.flags.irreversible.arc3).toBe(true)
   })
 
+  test('migrate arc3 asa with metadataHash auto-sets immutable', async () => {
+    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client, withMetadataHash: true })
+
+    // No flags provided - SDK should auto-set immutable
+    await migrateLegacyMetadataToRegistry({
+      registry,
+      assetManager,
+      assetId,
+      metadata: arc3Metadata,
+      arc3Compliant: true,
+    })
+
+    const header = await registry.read.arc89GetMetadataHeader({ assetId })
+    expect(header.flags.irreversible.immutable).toBe(true)
+    expect(header.flags.irreversible.arc3).toBe(true)
+  })
+
+  test('migrate arc3 asa with metadataHash and explicit immutable=false throws readable error', async () => {
+    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client, withMetadataHash: true })
+
+    const flags = new MetadataFlags({
+      reversible: ReversibleFlags.empty(),
+      irreversible: new IrreversibleFlags({ immutable: false }),
+    })
+
+    await expect(
+      migrateLegacyMetadataToRegistry({
+        registry,
+        assetManager,
+        assetId,
+        metadata: arc3Metadata,
+        arc3Compliant: true,
+        flags,
+      }),
+    ).rejects.toThrow('IMMUTABLE flag')
+  })
+
   test('migrate arc69 preserves exact metadata', async () => {
     const originalMetadata: Record<string, unknown> = {
       standard: 'arc69',

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, beforeAll } from 'vitest'
-import { algo } from '@algorandfoundation/algokit-utils'
+import { algo, Config } from '@algorandfoundation/algokit-utils'
+import { nullLogger } from '@algorandfoundation/algokit-utils/logging'
 import type { AlgorandClient } from '@algorandfoundation/algokit-utils'
 import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
 import { AddressWithSigners } from '@algorandfoundation/algokit-utils/transact'
@@ -23,8 +24,8 @@ import {
   getDeployer,
   createFactory,
   createFundedAccount,
-  createLegacyArc3Asa,
-  createLegacyArc69Asa,
+  createArc3Asa,
+  createArc69Asa,
   createArc3Payload,
 } from './helpers'
 
@@ -124,7 +125,7 @@ beforeAll(async () => {
 
 describe('migration uri derivation', () => {
   test('derive basic uri without compliance fragments', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     const uri = deriveMigrationUri({ registry, assetId, arc3: false })
     const parsed = Arc90Uri.parse(uri)
@@ -136,7 +137,7 @@ describe('migration uri derivation', () => {
   })
 
   test('derive uri with arc3 flag', async () => {
-    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client })
+    const assetId = await createArc3Asa({ assetManager, appClient: client, preRegistry: true })
 
     const uri = deriveMigrationUri({ registry, assetId, arc3: true })
     const parsed = Arc90Uri.parse(uri)
@@ -147,7 +148,7 @@ describe('migration uri derivation', () => {
 
 describe('build arc2 migration message txn', () => {
   test('build txn basic', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
     const metadataUri = 'arc90://net:testnet/123?box=AAAAAAAAAAM'
 
     const txn = await buildArc2MigrationMessageTxn({
@@ -172,7 +173,7 @@ describe('build arc2 migration message txn', () => {
   })
 
   test('build txn preserves manager', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
     const metadataUri = 'arc90://net:testnet/123?box=AAAAAAAAAAM'
 
     const txn = await buildArc2MigrationMessageTxn({
@@ -187,7 +188,7 @@ describe('build arc2 migration message txn', () => {
   })
 
   test('build txn preserves all roles', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
     const metadataUri = 'arc90://net:testnet/123?box=AAAAAAAAAAM'
 
     const txn = await buildArc2MigrationMessageTxn({
@@ -203,7 +204,7 @@ describe('build arc2 migration message txn', () => {
   })
 
   test('build txn without write capability error', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // Create read-only registry (no appClient)
     const readOnlyRegistry = AsaMetadataRegistry.fromAlgod({
@@ -224,14 +225,14 @@ describe('build arc2 migration message txn', () => {
 
 describe('pre-flight checks', () => {
   test('asset without metadata passes', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     const existence = await registry.read.arc89CheckMetadataExists({ assetId })
     expect(existence.metadataExists).toBe(false)
   })
 
   test('asset with existing metadata throws', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // Create metadata first
     const metadata = AssetMetadata.fromJson({
@@ -255,7 +256,7 @@ describe('pre-flight checks', () => {
 
 describe('migrate legacy metadata', () => {
   test('migrate minimal metadata', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     await migrateLegacyMetadataToRegistry({
       registry,
@@ -276,7 +277,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate arc3 metadata', async () => {
-    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client })
+    const assetId = await createArc3Asa({ assetManager, appClient: client, preRegistry: true })
 
     await migrateLegacyMetadataToRegistry({
       registry,
@@ -296,7 +297,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate arc3 asa with metadataHash auto-sets immutable', async () => {
-    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client, withMetadataHash: true })
+    const assetId = await createArc3Asa({ assetManager, appClient: client, preRegistry: true, withMetadataHash: true })
 
     // No flags provided - SDK should auto-set immutable
     await migrateLegacyMetadataToRegistry({
@@ -313,7 +314,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate arc3 asa with metadataHash and explicit immutable=false throws readable error', async () => {
-    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client, withMetadataHash: true })
+    const assetId = await createArc3Asa({ assetManager, appClient: client, preRegistry: true, withMetadataHash: true })
 
     const flags = new MetadataFlags({
       reversible: ReversibleFlags.empty(),
@@ -355,7 +356,7 @@ describe('migrate legacy metadata', () => {
       ],
     }
 
-    const assetId = await createLegacyArc69Asa({
+    const assetId = await createArc69Asa({
       assetManager,
       appClient: client,
       metadata: originalMetadata,
@@ -397,7 +398,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate with custom flags', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     const flags = new MetadataFlags({
       reversible: new ReversibleFlags({ reserved3: true }),
@@ -419,7 +420,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate with arc89 native flag throws', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     const flags = new MetadataFlags({
       reversible: ReversibleFlags.empty(),
@@ -439,7 +440,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate already migrated throws', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // First migration
     await migrateLegacyMetadataToRegistry({
@@ -463,7 +464,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate oversized metadata throws', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     const oversizedMetadata = {
       name: 'Oversized Asset',
@@ -482,7 +483,7 @@ describe('migrate legacy metadata', () => {
   })
 
   test('migrate max size metadata', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // Create metadata that fits within MAX_METADATA_SIZE
     const contentSize = MAX_METADATA_SIZE - 20 // Leave room for JSON structure
@@ -503,7 +504,7 @@ describe('migrate legacy metadata', () => {
 
 describe('rbac preservation', () => {
   test('preserve all roles after migration', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // Get original asset info
     const originalInfo = await algorand.asset.getById(assetId)
@@ -599,7 +600,7 @@ describe('rbac preservation', () => {
 
 describe('migration error handling', () => {
   test('migrate empty metadata', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     await migrateLegacyMetadataToRegistry({
       registry,
@@ -614,24 +615,29 @@ describe('migration error handling', () => {
   })
 
   test('migrate without manager throws', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
     const untrustedAccount = await createFundedAccount(fixture, algo(10))
-
-    await expect(
-      migrateLegacyMetadataToRegistry({
-        registry,
-        assetManager: untrustedAccount,
-        assetId,
-        metadata: minimalMetadata,
-        arc3Compliant: false,
-      }),
-    ).rejects.toThrow()
+    const prevLogger = Config.logger
+    Config.configure({ logger: nullLogger })
+    try {
+      await expect(
+        migrateLegacyMetadataToRegistry({
+          registry,
+          assetManager: untrustedAccount,
+          assetId,
+          metadata: minimalMetadata,
+          arc3Compliant: false,
+        }),
+      ).rejects.toThrow()
+    } finally {
+      Config.configure({ logger: prevLogger })
+    }
   })
 })
 
 describe('migration integration', () => {
   test('full migration workflow', async () => {
-    const assetId = await createLegacyArc3Asa({ assetManager, appClient: client })
+    const assetId = await createArc3Asa({ assetManager, appClient: client, preRegistry: true })
 
     // 1. Verify asset has no metadata initially
     const existenceBefore = await registry.read.arc89CheckMetadataExists({ assetId })
@@ -669,7 +675,7 @@ describe('migration integration', () => {
   })
 
   test('migration with subsequent updates', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // 1. Migrate
     await migrateLegacyMetadataToRegistry({
@@ -699,7 +705,7 @@ describe('migration integration', () => {
   })
 
   test('migration metadata size boundary', async () => {
-    const assetId = await createLegacyArc69Asa({ assetManager, appClient: client })
+    const assetId = await createArc69Asa({ assetManager, appClient: client })
 
     // Test short metadata
     const shortMeta = { x: 'a'.repeat(100) }


### PR DESCRIPTION
## Overview

When creating an ARC-89 metadata, if the metadata hash (`am`) field of the ASA is non-zero, the registry requires the immutable flag to be set. 

This PR handles this for legacy ASA migration https://github.com/algorandfoundation/asa-metadata-registry-ts/pull/110/commits/de1683152cd090caeaea70fefb56a29493263885: 

- Auto-sets the immutable flag if no flags provided by the caller. 
- If flags are provided, if forces that `immutable: true` is passed; else, gracefully throws.

The PR also adds a small refactor for test suite cleanness https://github.com/algorandfoundation/asa-metadata-registry-ts/pull/110/commits/f12fce55dd56266c310f3d3ceea5ffbab8a77c76.

## Test on Lora

Pull this version locally. Then, on `algokit-lora/package.json`:
```diff
  "dependencies": {
-   "@algorandfoundation/asa-metadata-registry-sdk": "^1.0.0-beta.5",
+   "@algorandfoundation/asa-metadata-registry-sdk": "file: /path/to/asa-metadata-registry-ts",
```
Lora integration PR: https://github.com/algorandfoundation/algokit-lora/pull/575/changes